### PR TITLE
Add Jest tests using real HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/.claude/settings.local.json
+node_modules/
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -1026,6 +1026,68 @@
         <span class="sr-only">Loading</span>
       </div>
     </div>
+
+    <!-- 41. Aqua Spin -->
+    <div class="loader-cell">
+      <div class="aqua-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="aqua-bar"></div>
+        <div class="aqua-bar"></div>
+        <div class="aqua-bar"></div>
+        <div class="aqua-bar"></div>
+        <div class="aqua-bar"></div>
+        <div class="aqua-bar"></div>
+        <div class="aqua-bar"></div>
+        <div class="aqua-bar"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 42. Bezel Bounce -->
+    <div class="loader-cell">
+      <div class="bezel-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="bezel-bar"></div>
+        <div class="bezel-bar"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 43. Wave Lines -->
+    <div class="loader-cell">
+      <div class="wave-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="wave-line"></div>
+        <div class="wave-line"></div>
+        <div class="wave-line"></div>
+        <div class="wave-line"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 44. Grid Flicker -->
+    <div class="loader-cell">
+      <div class="grid-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <div class="grid-block"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 45. Signal Bars -->
+    <div class="loader-cell">
+      <div class="signal-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="signal-bar"></div>
+        <div class="signal-bar"></div>
+        <div class="signal-bar"></div>
+        <div class="signal-bar"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
   </div>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -1110,6 +1110,8 @@
         <div class="aperture-blade"></div>
         <div class="aperture-blade"></div>
         <div class="aperture-blade"></div>
+        <div class="aperture-blade"></div>
+        <div class="aperture-blade"></div>
         <span class="sr-only">Loading</span>
       </div>
     </div>
@@ -1117,6 +1119,7 @@
     <!-- 49. Silk Slide -->
     <div class="loader-cell">
       <div class="silk-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="silk-line"></div>
         <div class="silk-line"></div>
         <div class="silk-line"></div>
         <div class="silk-line"></div>

--- a/index.html
+++ b/index.html
@@ -1088,6 +1088,50 @@
         <span class="sr-only">Loading</span>
       </div>
     </div>
+
+    <!-- 46. Titanium Spin -->
+    <div class="loader-cell">
+      <div class="titanium-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 47. Halo Glow -->
+    <div class="loader-cell">
+      <div class="halo-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 48. Aperture Swirl -->
+    <div class="loader-cell">
+      <div class="aperture-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="aperture-blade"></div>
+        <div class="aperture-blade"></div>
+        <div class="aperture-blade"></div>
+        <div class="aperture-blade"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 49. Silk Slide -->
+    <div class="loader-cell">
+      <div class="silk-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="silk-line"></div>
+        <div class="silk-line"></div>
+        <div class="silk-line"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
+
+    <!-- 50. Fusion Flash -->
+    <div class="loader-cell">
+      <div class="fusion-loader" role="status" aria-live="polite" aria-label="Loading…">
+        <div class="fusion-circle"></div>
+        <div class="fusion-circle"></div>
+        <span class="sr-only">Loading</span>
+      </div>
+    </div>
   </div>
 
   <script>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  testMatch: ['**/unit-tests.js']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "loading-indicators",
+  "version": "1.0.0",
+  "description": "Loading indicators demo with tests",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jest-environment-jsdom": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1703,6 +1703,127 @@ body {
   50% { opacity: 1; }
 }
 
+/* -------- 46. Titanium Spin -------- */
+.titanium-loader {
+  width: var(--base-size);
+  height: var(--base-size);
+  border-radius: 50%;
+  border: 4px solid var(--silver);
+  border-top-color: var(--carbon-black);
+  animation: titanium-spin 1s linear infinite;
+}
+
+@keyframes titanium-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* -------- 47. Halo Glow -------- */
+.halo-loader {
+  width: var(--base-size);
+  height: var(--base-size);
+  border-radius: 50%;
+  background: var(--apple-white);
+  box-shadow: 0 0 0 0 rgba(0,0,0,0.2);
+  animation: halo-pulse 1.5s ease-out infinite;
+}
+
+@keyframes halo-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(0,0,0,0.2); }
+  70% { box-shadow: 0 0 0 10px rgba(0,0,0,0); }
+  100% { box-shadow: 0 0 0 0 rgba(0,0,0,0); }
+}
+
+/* -------- 48. Aperture Swirl -------- */
+.aperture-loader {
+  position: relative;
+  width: var(--base-size);
+  height: var(--base-size);
+  border-radius: 50%;
+  overflow: hidden;
+  animation: aperture-spin 1.2s linear infinite;
+}
+
+.aperture-blade {
+  position: absolute;
+  width: 50%;
+  height: 50%;
+  background: var(--accent-purple);
+  transform-origin: 100% 100%;
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+}
+
+.aperture-loader .aperture-blade:nth-child(1) { transform: rotate(0deg); }
+.aperture-loader .aperture-blade:nth-child(2) { transform: rotate(90deg); }
+.aperture-loader .aperture-blade:nth-child(3) { transform: rotate(180deg); }
+.aperture-loader .aperture-blade:nth-child(4) { transform: rotate(270deg); }
+
+@keyframes aperture-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* -------- 49. Silk Slide -------- */
+.silk-loader {
+  position: relative;
+  width: var(--base-size);
+  height: calc(var(--base-size) / 3);
+  overflow: hidden;
+}
+
+.silk-line {
+  position: absolute;
+  width: 120%;
+  height: 100%;
+  background: var(--primary-blue);
+  opacity: 0.4;
+  animation: silk-slide 1.2s linear infinite;
+}
+
+.silk-line:nth-child(2) { animation-delay: 0.2s; }
+.silk-line:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes silk-slide {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+/* -------- 50. Fusion Flash -------- */
+.fusion-loader {
+  position: relative;
+  width: var(--base-size);
+  height: var(--base-size);
+}
+
+.fusion-circle {
+  position: absolute;
+  top: 50%;
+  width: 40%;
+  height: 40%;
+  border-radius: 50%;
+  background: var(--accent-coral);
+}
+
+.fusion-circle:nth-child(1) {
+  left: 0;
+  transform: translate(0, -50%);
+  animation: fusion-left 1s var(--ease-bounce) infinite;
+}
+
+.fusion-circle:nth-child(2) {
+  right: 0;
+  transform: translate(0, -50%);
+  animation: fusion-right 1s var(--ease-bounce) infinite;
+}
+
+@keyframes fusion-left {
+  0%, 100% { transform: translate(0, -50%); }
+  50% { transform: translate(50%, -50%); }
+}
+
+@keyframes fusion-right {
+  0%, 100% { transform: translate(0, -50%); }
+  50% { transform: translate(-50%, -50%); }
+}
+
 /* Respect reduced-motion preference */
 @media (prefers-reduced-motion: reduce) {
   .ep-loader, .mb-loader::before, .mb-loader::after,
@@ -1715,7 +1836,8 @@ body {
   .mc-node, .mc-connection, .df-stream, .nn-node, 
   .nn-connection::before, .rb-world, .rb-bridge::before,
   .rd-field, .one-more-text, .no-circle, .courage-ring,
-  .think-text, .innovation-circle, .apple-rainbow, .magical-side {
+  .think-text, .innovation-circle, .apple-rainbow, .magical-side,
+  .titanium-loader, .halo-loader, .aperture-blade, .silk-line, .fusion-circle {
     animation: none;
     opacity: 0.6;
   }

--- a/styles.css
+++ b/styles.css
@@ -1722,15 +1722,26 @@ body {
   width: var(--base-size);
   height: var(--base-size);
   border-radius: 50%;
-  background: var(--apple-white);
-  box-shadow: 0 0 0 0 rgba(0,0,0,0.2);
-  animation: halo-pulse 1.5s ease-out infinite;
+  background: radial-gradient(circle at center,
+      var(--apple-white) 40%, var(--soft-blue));
+  box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--primary-blue) 50%, transparent);
+  animation: halo-pulse 2s var(--ease-apple) infinite;
 }
 
 @keyframes halo-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(0,0,0,0.2); }
-  70% { box-shadow: 0 0 0 10px rgba(0,0,0,0); }
-  100% { box-shadow: 0 0 0 0 rgba(0,0,0,0); }
+  0% {
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--primary-blue) 50%, transparent);
+  }
+  70% {
+    box-shadow: 0 0 0 16px
+      color-mix(in srgb, var(--primary-blue) 0%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--primary-blue) 0%, transparent);
+  }
 }
 
 /* -------- 48. Aperture Swirl -------- */
@@ -1740,22 +1751,29 @@ body {
   height: var(--base-size);
   border-radius: 50%;
   overflow: hidden;
-  animation: aperture-spin 1.2s linear infinite;
+  animation: aperture-spin 1.6s linear infinite;
 }
 
 .aperture-blade {
   position: absolute;
   width: 50%;
   height: 50%;
-  background: var(--accent-purple);
+  background: linear-gradient(
+      to bottom right,
+      var(--accent-purple),
+      var(--primary-blue)
+  );
+  opacity: 0.85;
   transform-origin: 100% 100%;
   clip-path: polygon(0 0, 100% 0, 0 100%);
 }
 
 .aperture-loader .aperture-blade:nth-child(1) { transform: rotate(0deg); }
-.aperture-loader .aperture-blade:nth-child(2) { transform: rotate(90deg); }
-.aperture-loader .aperture-blade:nth-child(3) { transform: rotate(180deg); }
-.aperture-loader .aperture-blade:nth-child(4) { transform: rotate(270deg); }
+.aperture-loader .aperture-blade:nth-child(2) { transform: rotate(60deg); }
+.aperture-loader .aperture-blade:nth-child(3) { transform: rotate(120deg); }
+.aperture-loader .aperture-blade:nth-child(4) { transform: rotate(180deg); }
+.aperture-loader .aperture-blade:nth-child(5) { transform: rotate(240deg); }
+.aperture-loader .aperture-blade:nth-child(6) { transform: rotate(300deg); }
 
 @keyframes aperture-spin {
   to { transform: rotate(360deg); }
@@ -1771,19 +1789,25 @@ body {
 
 .silk-line {
   position: absolute;
-  width: 120%;
+  width: 140%;
   height: 100%;
-  background: var(--primary-blue);
-  opacity: 0.4;
-  animation: silk-slide 1.2s linear infinite;
+  background: linear-gradient(
+      to right,
+      var(--accent-coral),
+      var(--primary-blue)
+  );
+  opacity: 0.5;
+  transform: skewX(-20deg);
+  animation: silk-slide 1.4s linear infinite;
 }
 
 .silk-line:nth-child(2) { animation-delay: 0.2s; }
 .silk-line:nth-child(3) { animation-delay: 0.4s; }
+.silk-line:nth-child(4) { animation-delay: 0.6s; }
 
 @keyframes silk-slide {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+  0% { transform: translateX(-100%) skewX(-20deg); }
+  100% { transform: translateX(100%) skewX(-20deg); }
 }
 
 /* -------- 50. Fusion Flash -------- */
@@ -1796,32 +1820,45 @@ body {
 .fusion-circle {
   position: absolute;
   top: 50%;
-  width: 40%;
-  height: 40%;
+  width: 35%;
+  height: 35%;
   border-radius: 50%;
   background: var(--accent-coral);
 }
 
 .fusion-circle:nth-child(1) {
   left: 0;
-  transform: translate(0, -50%);
-  animation: fusion-left 1s var(--ease-bounce) infinite;
+  transform: translate(0, -50%) scale(0.8);
+  animation: fusion-left 1.2s var(--ease-precise) infinite;
 }
 
 .fusion-circle:nth-child(2) {
   right: 0;
-  transform: translate(0, -50%);
-  animation: fusion-right 1s var(--ease-bounce) infinite;
+  background: var(--primary-blue);
+  transform: translate(0, -50%) scale(0.8);
+  animation: fusion-right 1.2s var(--ease-precise) infinite;
 }
 
 @keyframes fusion-left {
-  0%, 100% { transform: translate(0, -50%); }
-  50% { transform: translate(50%, -50%); }
+  0%, 100% {
+    transform: translate(0, -50%) scale(0.8);
+    background: var(--accent-coral);
+  }
+  50% {
+    transform: translate(50%, -50%) scale(1.2);
+    background: var(--accent-purple);
+  }
 }
 
 @keyframes fusion-right {
-  0%, 100% { transform: translate(0, -50%); }
-  50% { transform: translate(-50%, -50%); }
+  0%, 100% {
+    transform: translate(0, -50%) scale(0.8);
+    background: var(--primary-blue);
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.2);
+    background: var(--accent-purple);
+  }
 }
 
 /* Respect reduced-motion preference */

--- a/styles.css
+++ b/styles.css
@@ -17,9 +17,11 @@ body {
 
 .indicators-container {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 50px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 40px;
   padding: 40px;
+  max-width: 1200px;
+  margin: auto;
 }
 
 .loader-cell {
@@ -1564,6 +1566,141 @@ body {
 @keyframes magical-reveal {
   0%, 100% { transform: rotateY(0deg); }
   50% { transform: rotateY(180deg); }
+}
+
+/* -------- 41. Aqua Spin -------- */
+.aqua-loader {
+  position: relative;
+  width: var(--base-size);
+  height: var(--base-size);
+}
+
+.aqua-bar {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: calc(var(--base-size) / 10);
+  height: calc(var(--base-size) / 3);
+  background: var(--primary-blue);
+  border-radius: calc(var(--base-size) / 20);
+  transform-origin: center calc(var(--base-size) / -4);
+  opacity: 0.2;
+  animation: aqua-fade 1s linear infinite;
+}
+
+.aqua-loader .aqua-bar:nth-child(1) { transform: rotate(0deg); animation-delay: 0s; }
+.aqua-loader .aqua-bar:nth-child(2) { transform: rotate(45deg); animation-delay: 0.125s; }
+.aqua-loader .aqua-bar:nth-child(3) { transform: rotate(90deg); animation-delay: 0.25s; }
+.aqua-loader .aqua-bar:nth-child(4) { transform: rotate(135deg); animation-delay: 0.375s; }
+.aqua-loader .aqua-bar:nth-child(5) { transform: rotate(180deg); animation-delay: 0.5s; }
+.aqua-loader .aqua-bar:nth-child(6) { transform: rotate(225deg); animation-delay: 0.625s; }
+.aqua-loader .aqua-bar:nth-child(7) { transform: rotate(270deg); animation-delay: 0.75s; }
+.aqua-loader .aqua-bar:nth-child(8) { transform: rotate(315deg); animation-delay: 0.875s; }
+
+@keyframes aqua-fade {
+  0%, 100% { opacity: 0.2; }
+  50% { opacity: 1; }
+}
+
+/* -------- 42. Bezel Bounce -------- */
+.bezel-loader {
+  display: flex;
+  align-items: flex-end;
+  width: var(--base-size);
+  height: calc(var(--base-size) / 3);
+  gap: calc(var(--base-size) / 10);
+}
+
+.bezel-bar {
+  flex: 1;
+  height: 100%;
+  background: var(--accent-coral);
+  border-radius: 2px;
+  animation: bezel-bounce 1s var(--ease-bounce) infinite;
+}
+
+.bezel-bar:nth-child(2) { animation-delay: 0.2s; }
+
+@keyframes bezel-bounce {
+  0%, 100% { transform: scaleY(0.5); }
+  50% { transform: scaleY(1); }
+}
+
+/* -------- 43. Wave Lines -------- */
+.wave-loader {
+  display: flex;
+  gap: calc(var(--base-size) / 12);
+}
+
+.wave-line {
+  width: calc(var(--base-size) / 8);
+  height: calc(var(--base-size) / 2);
+  background: var(--primary-blue);
+  border-radius: calc(var(--base-size) / 16);
+  animation: wave-rise 1.2s var(--ease-natural) infinite;
+}
+
+.wave-line:nth-child(2) { animation-delay: 0.1s; }
+.wave-line:nth-child(3) { animation-delay: 0.2s; }
+.wave-line:nth-child(4) { animation-delay: 0.3s; }
+
+@keyframes wave-rise {
+  0%, 100% { transform: scaleY(0.3); }
+  50% { transform: scaleY(1); }
+}
+
+/* -------- 44. Grid Flicker -------- */
+.grid-loader {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+  width: calc(var(--base-size) * 0.9);
+  height: calc(var(--base-size) * 0.9);
+}
+
+.grid-block {
+  background: var(--primary-blue);
+  animation: grid-fade 1.2s linear infinite;
+}
+
+.grid-block:nth-child(2) { animation-delay: 0.1s; }
+.grid-block:nth-child(3) { animation-delay: 0.2s; }
+.grid-block:nth-child(4) { animation-delay: 0.3s; }
+.grid-block:nth-child(5) { animation-delay: 0.4s; }
+.grid-block:nth-child(6) { animation-delay: 0.5s; }
+.grid-block:nth-child(7) { animation-delay: 0.6s; }
+.grid-block:nth-child(8) { animation-delay: 0.7s; }
+.grid-block:nth-child(9) { animation-delay: 0.8s; }
+
+@keyframes grid-fade {
+  0%, 100% { opacity: 0.2; }
+  50% { opacity: 1; }
+}
+
+/* -------- 45. Signal Bars -------- */
+.signal-loader {
+  display: flex;
+  align-items: flex-end;
+  gap: calc(var(--base-size) / 12);
+  width: var(--base-size);
+  height: calc(var(--base-size) / 2);
+}
+
+.signal-bar {
+  width: calc(var(--base-size) / 8);
+  background: var(--primary-blue);
+  border-radius: 2px;
+  animation: signal-rise 1s var(--ease-bounce) infinite;
+}
+
+.signal-bar:nth-child(1) { height: 20%; animation-delay: 0s; }
+.signal-bar:nth-child(2) { height: 40%; animation-delay: 0.1s; }
+.signal-bar:nth-child(3) { height: 60%; animation-delay: 0.2s; }
+.signal-bar:nth-child(4) { height: 80%; animation-delay: 0.3s; }
+
+@keyframes signal-rise {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
 }
 
 /* Respect reduced-motion preference */

--- a/unit-tests.js
+++ b/unit-tests.js
@@ -38,7 +38,8 @@ describe('Loading Indicators', () => {
       'cp-loader', 'ss-loader', 'cou-loader', 'mc-loader', 'df-loader',
       'nn-loader', 'rb-loader', 'rd-loader', 'one-more-loader', 'thousand-nos-loader',
       'courage-loader', 'think-loader', 'innovation-loader', 'apple-loader', 'magical-loader',
-      'aqua-loader', 'bezel-loader', 'wave-loader', 'grid-loader', 'signal-loader'
+      'aqua-loader', 'bezel-loader', 'wave-loader', 'grid-loader', 'signal-loader',
+      'titanium-loader', 'halo-loader', 'aperture-loader', 'silk-loader', 'fusion-loader'
     ];
     
     test.each(loaderTypes)('Loader %s exists in the DOM', (loaderClass) => {
@@ -116,7 +117,8 @@ describe('Loading Indicators', () => {
       'nn-loader', 'rb-loader', 'rd-loader', 'one-more-loader',
       'thousand-nos-loader', 'courage-loader', 'think-loader',
       'innovation-loader', 'apple-loader', 'magical-loader',
-      'aqua-loader', 'bezel-loader', 'wave-loader', 'grid-loader', 'signal-loader'
+      'aqua-loader', 'bezel-loader', 'wave-loader', 'grid-loader', 'signal-loader',
+      'titanium-loader', 'halo-loader', 'aperture-loader', 'silk-loader', 'fusion-loader'
     ];
     
     test.each(lastLoaders)('%s has correct children elements', (loaderClass) => {

--- a/unit-tests.js
+++ b/unit-tests.js
@@ -15,18 +15,16 @@
 // Sample Jest test implementation
 
 describe('Loading Indicators', () => {
-  // Set up the document with our loading indicators
+  // Load the actual HTML and CSS so tests can query real elements
   beforeAll(() => {
-    // This would typically load the HTML content
-    document.body.innerHTML = `
-      <div class="indicators-container">
-        <!-- All loaders would be here -->
-      </div>
-    `;
-    
-    // Add the styles
+    const fs = require('fs');
+    const html = fs.readFileSync(require.resolve('./index.html'), 'utf8');
+    const css = fs.readFileSync(require.resolve('./styles.css'), 'utf8');
+
+    document.documentElement.innerHTML = html;
+
     const styleElement = document.createElement('style');
-    styleElement.textContent = `/* CSS content would be here */`;
+    styleElement.textContent = css;
     document.head.appendChild(styleElement);
   });
 
@@ -39,7 +37,8 @@ describe('Loading Indicators', () => {
       'omt-loader', 'ib-loader', 'fe-loader', 'tn-loader', 'ig-loader',
       'cp-loader', 'ss-loader', 'cou-loader', 'mc-loader', 'df-loader',
       'nn-loader', 'rb-loader', 'rd-loader', 'one-more-loader', 'thousand-nos-loader',
-      'courage-loader', 'think-loader', 'innovation-loader', 'apple-loader', 'magical-loader'
+      'courage-loader', 'think-loader', 'innovation-loader', 'apple-loader', 'magical-loader',
+      'aqua-loader', 'bezel-loader', 'wave-loader', 'grid-loader', 'signal-loader'
     ];
     
     test.each(loaderTypes)('Loader %s exists in the DOM', (loaderClass) => {
@@ -114,9 +113,10 @@ describe('Loading Indicators', () => {
   // Testing specific loaders (example with the last 8-12 loaders)
   describe('Last 8-12 Loaders Tests', () => {
     const lastLoaders = [
-      'nn-loader', 'rb-loader', 'rd-loader', 'one-more-loader', 
-      'thousand-nos-loader', 'courage-loader', 'think-loader', 
-      'innovation-loader', 'apple-loader', 'magical-loader'
+      'nn-loader', 'rb-loader', 'rd-loader', 'one-more-loader',
+      'thousand-nos-loader', 'courage-loader', 'think-loader',
+      'innovation-loader', 'apple-loader', 'magical-loader',
+      'aqua-loader', 'bezel-loader', 'wave-loader', 'grid-loader', 'signal-loader'
     ];
     
     test.each(lastLoaders)('%s has correct children elements', (loaderClass) => {

--- a/unit-tests.js
+++ b/unit-tests.js
@@ -131,8 +131,13 @@ describe('Loading Indicators', () => {
       } else if (loaderClass === 'rb-loader') {
         expect(loader?.querySelectorAll('.rb-world').length).toBe(2);
         expect(loader?.querySelector('.rb-bridge')).not.toBeNull();
+      } else if (loaderClass === 'aperture-loader') {
+        expect(loader?.querySelectorAll('.aperture-blade').length).toBe(6);
+      } else if (loaderClass === 'silk-loader') {
+        expect(loader?.querySelectorAll('.silk-line').length).toBe(4);
+      } else if (loaderClass === 'fusion-loader') {
+        expect(loader?.querySelectorAll('.fusion-circle').length).toBe(2);
       }
-      // Add checks for other loaders
     });
   });
 });


### PR DESCRIPTION
## Summary
- install Jest and jsdom
- configure Jest and ignore generated files
- load actual HTML/CSS in unit tests
- make loader grid responsive with auto-fit and center layout
- add new Aqua Spin, Bezel Bounce, Wave Lines, Grid Flicker, and Signal Bars loaders

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e4c0817508322afbf32e73787db93